### PR TITLE
Copyright filename support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,19 @@ Just search for `file-header` in Atom `Settings > Install`, and press `Install`.
 # Customise Template
 FileHeader came with a pre-defiend language-to-template mappings (`lang-mapping.json`) and bunch of template files (`templates/*`). Check them out in the `lib` directory of FileHeader package. You are free to override or partially override them in your own config directory. Check out the option `Config Directory Path` from FileHeader settings for details.
 
+# Template Variables
+| variable           | description                             |
+|--------------------|-----------------------------------------|
+| author             | the name of the author                  |
+| email              | the email of the author                 |
+| project_name       | the name of the current project         |
+| filename           | the name of the file                    |
+| copyright          | the copyright text                      |
+| license            | the license statement                   |
+| create_time        | the time the file is created at         |
+| last_modified_by   | user who last modified the file         |
+| last_modified_time | the time the file is last modified at   |
+
 # Language Specific Setting
 Apart from general configurations in FileHeader's settings, you can also configure everything language specific directly in your `config.cson` file (`Atom > Open Your Config`):
 

--- a/lib/file-header.coffee
+++ b/lib/file-header.coffee
@@ -303,7 +303,18 @@ module.exports = FileHeader =
         result.replace('')
       result.stop()
     )
-    buffer.insert([0, 0], newHeader, normalizeLineEndings: true)
+    
+    point = @getBeginningHeaderPoint editor, buffer
+    buffer.insert(point, newHeader, normalizeLineEndings: true)
+
+  getBeginningHeaderPoint: (editor, buffer) ->
+    if editor.getRootScopeDescriptor().getScopesArray()[0] ==  'text.html.php'
+      point = [0, 0]
+      buffer.scan(/^(<\u003Fphp)|^(<\u003f)/, (result) =>
+        point = result.range.start
+        point.row += 1
+      )
+      return point
 
   add: (manual = false) ->
     return unless editor = atom.workspace.getActiveTextEditor()

--- a/lib/file-header.coffee
+++ b/lib/file-header.coffee
@@ -2,7 +2,7 @@
 # @Date:   2016-02-13T14:15:43+11:00
 # @Email:  root@guiguan.net
 # @Last modified by:   eric
-# @Last modified time: 2016-10-28
+# @Last modified time: 2016-10-29
 
 
 
@@ -141,7 +141,7 @@ module.exports = FileHeader =
       # now use `isEmpty` to determine if the file is just __created__
       # however, if an empty file is __open__, we will still try to
       # add the file header automatically
-      if autoAddHeaderOnNewFile && editor.isEmpty()
+      if autoAddHeaderOnNewFile && editor.isEmpty() && !@isInIgnoreListForAutoUpdateAndAddingHeader(editor)
         headerTemplate = @getHeaderTemplate editor
         if headerTemplate
           buffer = editor.getBuffer()
@@ -191,11 +191,10 @@ module.exports = FileHeader =
     username = atom.config.get 'file-header.username', scope: (do editor.getRootScopeDescriptor)
     email = atom.config.get 'file-header.email', scope: (do editor.getRootScopeDescriptor)
     copyright = atom.config.get 'file-header.copyright', scope: (do editor.getRootScopeDescriptor)
-    filename = atom.workspace.getActiveTextEditor()?.buffer?.file?.getBaseName();
+    filename = editor.buffer.file.getBaseName()
 
     if filename
-      # fill placeholder {{file_name}}
-      headerTemplate = headerTemplate.replace(/\{\{file_name\}\}/g, filename)
+      # fill placeholder {{filename}}
       headerTemplate = headerTemplate.replace(/\{\{filename\}\}/g, filename)
 
     if copyright


### PR DESCRIPTION
- Added {{filename}} and {{copyright}} support in the file header template.
- Allow automatically add file header (w/ ignore list support) when add a new file (New > File... )
- Added an autoAddHeaderOnNewFile config option which can enable or disable the feature above
- Update the README by adding all supported template variables
