### PR TITLE
Change header body to follow same line endings as default

### DIFF
--- a/lib/file-header.coffee
+++ b/lib/file-header.coffee
@@ -322,6 +322,7 @@ module.exports = FileHeader =
 
   addHeader: (editor, buffer, headerTemplate) ->
     return unless newHeader = @getNewHeader editor, headerTemplate
+	newHeader = newHeader.replace(/(?:\r\n|\r|\n)/g, @getCurrentFileLineEnding(buffer))
     newHeader += @getCurrentFileLineEnding(buffer).repeat(atom.config.get('file-header.numOfEmptyLinesAfterNewHeader', scope: (do editor.getRootScopeDescriptor)))
     # remove leading empty lines
     buffer.scan(/\s*(?:\r\n|\r|\n)(?=\S)/, (result) =>


### PR DESCRIPTION
@getCurrentFileLineEnding only referenced the empty lines after a new header, causing conflicts between what line ending the actual header used and the spacing before the code. This regex statement would replace all line endings for the actual header, regardless of what line endings were used on the templates (AKA it automatically follows what the user configures it to be)

Resolves: #55