### PR TITLE
Fixed the auto Username Reset Bug

### DIFF
--- a/lib/file-header.coffee
+++ b/lib/file-header.coffee
@@ -1,8 +1,8 @@
 # @Author: Guan Gui <guiguan>
 # @Date:   2016-02-13T14:15:43+11:00
 # @Email:  root@guiguan.net
-# @Last modified by:   guiguan
-# @Last modified time: 2018-02-14T11:28:22+11:00
+# @Last modified by:   kartikay101
+# @Last modified time: 2018-07-29T17:09:35+05:30
 
 
 
@@ -126,7 +126,12 @@ module.exports = FileHeader =
       # if it is the first time this plugin is installed, we try to setup username
       # for the user
       atom.config.set('file-header.username', process.env.USER ? '')
-
+      #if the first if statement fails, it somehow does not initialize the "notFirstTime" property and
+      #the next serialization operation would not save it
+      #causing the First Time setup to trigger again and it will reset the fileheader to the default username
+    else
+      @state=state
+      @state.notFirstTime=true
     # Events subscribed to in atom's system can be easily cleaned up
     # with a CompositeDisposable
     @subscriptions = new CompositeDisposable

--- a/lib/file-header.coffee
+++ b/lib/file-header.coffee
@@ -2,7 +2,7 @@
 # @Date:   2016-02-13T14:15:43+11:00
 # @Email:  root@guiguan.net
 # @Last modified by:   kartikay101
-# @Last modified time: 2018-07-29T17:09:35+05:30
+# @Last modified time: 2018-07-29T17:46:19+05:30
 
 
 
@@ -121,14 +121,16 @@ module.exports = FileHeader =
 
   activate: (state) ->
     if !state.notFirstTime
-      @state = state
-      @state.notFirstTime = true
+      # added the property notFirstTime to the previous aquired state
+      # instead of the currrent state and then set it to the current state
+      state.notFirstTime = true
+      @state=state
       # if it is the first time this plugin is installed, we try to setup username
       # for the user
       atom.config.set('file-header.username', process.env.USER ? '')
-      #if the first if statement fails, it somehow does not initialize the "notFirstTime" property and
-      #the next serialization operation would not save it
-      #causing the First Time setup to trigger again and it will reset the fileheader to the default username
+      # if the first if statement fails, it somehow does not initialize the "notFirstTime" property and
+      # the next serialization operation would not save it
+      # causing the First Time setup to trigger again and it will reset the fileheader to the default username
     else
       @state=state
       @state.notFirstTime=true


### PR DESCRIPTION
The changes in the code fix the resetting of the Username to the default value after restarting the atom editor

Issues : 1. First time intialization triggers the !notfirstTime flag and the username is reset to the default value (just as it should) but the second time restart will trigger the same as the serializer won't get a notFirstTime flag from the current state (as only the current state is sent to the serialization function)

Fix: Added an else statement for generating the notFirstTime flag even when it is not the first time (check code for better understanding)
This fixed the issue of changing Username in the same environment. (from where it has been opened)

Issue : 2 The above did not fix the change of Username when atom is opened from a new console window (any other environment)

Fix : Instead of adding the notFirstTime flag to the current environment and writing a deseralizer for it, I added the same property to the pre-received state object and pointed it to the current state. (check code for better understanding)

This seems to have fixed both the issues.

PS: Test and merge, if there are any bugs caused by my code, I'll be glad to look at them.