### PR TITLE
Update file-header.coffee

### DIFF
--- a/lib/file-header.coffee
+++ b/lib/file-header.coffee
@@ -3,8 +3,8 @@
 # @Email:  root@guiguan.net
 # @Project: file-header
 # @Filename: lib/file-header.coffee
-# @Last modified by:   Nate Hyson (nate@cldmv.net)
-# @Last modified time: 2019-09-04T18:32:15-07:00
+# @Last modified by:   Nate Hyson <CLDMV> (nate@cldmv.net)
+# @Last modified time: 2019-09-04T18:38:27-07:00
 
 
 

--- a/lib/file-header.coffee
+++ b/lib/file-header.coffee
@@ -4,7 +4,7 @@
 # @Project: file-header
 # @Filename: lib/file-header.coffee
 # @Last modified by:   Nate Hyson <CLDMV> (nate@cldmv.net)
-# @Last modified time: 2019-09-04T18:38:27-07:00
+# @Last modified time: 2019-09-05T10:02:33-07:00
 
 
 
@@ -139,7 +139,10 @@ module.exports = FileHeader =
       @state.notFirstTime = true
       # if it is the first time this plugin is installed, we try to setup username
       # for the user
-      atom.config.set('file-header.username', process.env.USER ? '')
+      username = atom.config.get 'file-header.username'
+      # Lets see if a value is set. For some reason the state is being cleared. Usually happening after a restart of the OS.
+      if !username or username == ''
+        atom.config.set('file-header.username', process.env.USER ? '')
 
     # Events subscribed to in atom's system can be easily cleaned up
     # with a CompositeDisposable
@@ -311,13 +314,12 @@ module.exports = FileHeader =
       # fill placeholder {{license}}
       headerTemplate = headerTemplate.replace(/\{\{license\}\}/g, license)
 
-    copyright = atom.config.get 'file-header.copyright', scope: (do editor.getRootScopeDescriptor)
     filename = if (atom.config.get 'file-header.enableFilename', scope: (do editor.getRootScopeDescriptor)) then @getFilePathName(editor)
-
     if filename
       # fill placeholder {{filename}}
       headerTemplate = headerTemplate.replace(/\{\{filename\}\}/g, filename)
 
+    copyright = atom.config.get 'file-header.copyright', scope: (do editor.getRootScopeDescriptor)
     if copyright
       # fill placeholder {{copyright}}
       headerTemplate = headerTemplate.replace(/\{\{copyright\}\}/g, copyright)

--- a/lib/file-header.coffee
+++ b/lib/file-header.coffee
@@ -3,8 +3,8 @@
 # @Email:  root@guiguan.net
 # @Project: file-header
 # @Filename: lib/file-header.coffee
-# @Last modified by:   Nate Hyson <CLDMV> (nate@cldmv.net)
-# @Last modified time: 2019-09-05T10:02:33-07:00
+# @Last modified by:   Nate Hyson <CLDMV> (nate+git-public@cldmv.net)
+# @Last modified time: 2019-09-05T13:52:40-07:00
 
 
 
@@ -246,6 +246,7 @@ module.exports = FileHeader =
 
   getProjectName: (editor) ->
     return null unless editor.buffer.file
+    # repository = atom.project.getRepositoryForDirectory('/path/to/project');
     projectNameSetting = atom.config.get 'file-header.projectName', scope: (do editor.getRootScopeDescriptor)
     project = @getProject(editor)
     return projectNameSetting unless project
@@ -275,6 +276,25 @@ module.exports = FileHeader =
       author: author
       byName: byName
     configData
+
+  getCopyright: (editor) ->
+    return null unless editor
+    copyright = atom.config.get 'file-header.copyright', scope: (do editor.getRootScopeDescriptor)
+    return null unless copyright
+    # re = new RegExp("%([a-zA-Z]+)(?:\b|\r\n|\r|\n|\s)", 'g')
+    # The above SHOULD work. But for some reason it doesn't. So lets go old school here.
+    re = /%([a-zA-Z]+)(?:\b|\r\n|\r|\n|\s)/g;
+
+    while m = re.exec(copyright)
+      # This is necessary to avoid infinite loops with zero-width matches
+      if m.index == re.lastIndex
+        re.lastIndex++
+      anchor = m[0]
+      format = m[1]
+      parsed = moment().format(format);
+      if moment(parsed, format, true).isValid()
+        copyright = copyright.replace(anchor, parsed)
+    copyright
 
   getNewHeader: (editor, headerTemplate) ->
     return null unless headerTemplate
@@ -319,7 +339,7 @@ module.exports = FileHeader =
       # fill placeholder {{filename}}
       headerTemplate = headerTemplate.replace(/\{\{filename\}\}/g, filename)
 
-    copyright = atom.config.get 'file-header.copyright', scope: (do editor.getRootScopeDescriptor)
+    copyright = @getCopyright(editor)
     if copyright
       # fill placeholder {{copyright}}
       headerTemplate = headerTemplate.replace(/\{\{copyright\}\}/g, copyright)

--- a/package.json
+++ b/package.json
@@ -15,6 +15,11 @@
     {
       "name": "Paul Joannon",
       "web": "http://paulloz.com"
+  	},
+    {
+      "name": "Nate Hyson",
+      "email": "nate+git-public@cldmv.net",
+      "web": "http://cldmv.net"
     }
   ],
   "keywords": [


### PR DESCRIPTION
- Add Project name Settings
  - enableProjectName
  - projectNameAuto
- Update Filename in file-header to use relative path and filename while a project is open in Atom
- Update Project Name to auto detect an open project. Also only insert the project name into files inside that project.
- Update the last_modified_by header to include real name, username and email if present as modificators may need to be contacted. Might need some settings for this later.
- Fix Username being cleared or reset to process env user upon restart of computer
- Add moment support to copyright field. Simply prepend % to any moment valid format and when the copyright it processed it will replace with the current values.
  - %YYYY is valid
  - %YYYY-MM is NOT valid, use %YYYY-%MM instead